### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,5 @@
+site: https://libre.solar/mppt-1210-hus/
+bom: build/mppt-1210-hus_bom.csv
+eda:
+  type: kicad
+  pcb: kicad/mppt-1210-hus.kicad_pcb


### PR DESCRIPTION
Hi, I thought this would be a good project for [kitspace.org](https://kitspace.org). It's our open source site that tries to make it easier for people to actually buy the parts and re-build OSHW electronics. I added the kitspace.yaml manifest file that makes sure we pick up the correct files. 

Here is a [preview](http://try-mppt.preview.kitspace.org/boards/github.com/kitspace-forks/mppt-1210-hus/) of what it would look like. If you are happy to add it just merge this. The page would keep updating with this repo in the future (every 3 hours or so). 

The BOM could be improved a bit, in-order to get the 1-click "Buy Parts" links to show up. I would be happy to provide access to the [bom-builder](https://github.com/kitspace/bom-builder) ([more info](https://kitspace.org/bom-builder)) to help you with that (just email me: kaspar@kitspace.org). 